### PR TITLE
Fix build by adding filesystem cleanup and njobs

### DIFF
--- a/.github/workflows/developer-docker-image.yml
+++ b/.github/workflows/developer-docker-image.yml
@@ -2,9 +2,9 @@ name: Build developer image
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
 
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build the Docker image
-      run: docker build . --file developer/Dockerfile --tag developer:$(date +%s)
+      run: docker build --build-arg njobs=2 --file developer/Dockerfile --tag developer:$(date +%s) .

--- a/developer/Dockerfile
+++ b/developer/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:22.04
-
-# docker build -t mfem-developer .
+ARG njobs
+ENV njobs=${njobs}
+# docker build --buildarg njobs=2 -t mfem-developer .
 
 RUN apt-get update && apt-get install -y \
     supervisor curl git git-lfs clang clang-tools cmake autoconf \
@@ -22,12 +23,12 @@ RUN useradd --create-home --shell /bin/bash euler
 RUN curl -L https://github.com/hypre-space/hypre/archive/refs/tags/v2.19.0.tar.gz > /opt/archives/hypre-v2.19.0.tar.gz
 RUN tar xzf hypre-v2.19.0.tar.gz && cd hypre-2.19.0/src && \
     ./configure --prefix /usr/local --enable-shared --disable-static && \
-    make -j && make install
+    make -j ${njobs} && make install
 
 # metis
 RUN curl -L https://github.com/mfem/tpls/blob/gh-pages/metis-5.1.0.tar.gz?raw=true > /opt/archives/metis-5.1.0.tgz
 RUN tar xzf metis-5.1.0.tgz && cd metis-5.1.0 && \
-    make config shared=1 cc=mpicc prefix=/usr/local && make -j && make install
+    make config shared=1 cc=mpicc prefix=/usr/local && make -j ${njobs} && make install
 
 # OpenVSCode server
 RUN curl -L https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-v1.69.1/openvscode-server-v1.69.1-linux-x64.tar.gz > \
@@ -41,7 +42,7 @@ WORKDIR /home/euler
 RUN git clone --depth=1 https://github.com/mfem/mfem.git mfem
 ADD --chown=euler:euler developer/user.mk mfem/config/user.mk
 # Run config/make s.t. first use is a bit quicker
-RUN cd mfem && make config && make -j && cd examples && make ex1 && make ex1p
+RUN cd mfem && make config && make -j ${njobs} && cd examples && make ex1 && make ex1p
 
 RUN curl -L https://github.com/aaugustin/websockets/archive/refs/tags/10.3.tar.gz > ./websockets-10.3.tar.gz && \
     tar xzf websockets-10.3.tar.gz && \


### PR DESCRIPTION
Okay now it's ready! So there were two things happening:

1. Running out of disk space I suspect - when I added an action to clean it up, the build lasted much longer.
2. Using -j in the container (without a number) to not constrain the jobs strangely made it run longer and eventually get "disconnected" by the remote provider. I have a feeling it triggered some "uhoh something is trying to mess with security" alert.

So to fix, I just added the cleanup and then limited -j to 2, and as a build arg so you don't need to when running on your local machine! And hopefully it wasn't a spurious bug and will work here too.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>