### PR TITLE
Build and push sm75 images

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -46,10 +46,12 @@ jobs:
           docker compose build cpu-tpls
           docker compose build --build-arg base_image=cpu-tpls developer-cpu
 
-      - name: build cuda-sm89 images
+      - name: build cuda images
         run: |
           docker compose build --build-arg cuda_arch_sm=89 cuda
           docker compose build developer-cuda
+          docker compose build --build-arg cuda_arch_sm=75 cuda
+          docker compose build --build-arg cuda_arch_sm=75 developer-cuda
 
   build-and-push-base:
     name: build and push base image
@@ -157,3 +159,40 @@ jobs:
 
       - name: push developer-cuda-sm89 image
         run: docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PREFIX }}/developer-cuda-sm89:$IMAGE_TAG"
+
+  build-and-push-cuda-sm75:
+    name: build and push cuda-sm75 images
+    needs: build-and-push-base
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build cuda-sm75 image
+        run: |
+          docker compose build --build-arg cuda_arch_sm=75 cuda
+          docker image tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PREFIX }}/cuda:latest \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PREFIX }}/cuda-sm75:$IMAGE_TAG"
+
+      - name: push cuda-sm75 image
+        run: docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PREFIX }}/cuda-sm75:$IMAGE_TAG"
+
+      - name: build developer-cuda-sm75 image
+        run: |
+          docker compose build --build-arg cuda_arch_sm=75 developer-cuda
+          docker image tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PREFIX }}/developer-cuda:latest \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PREFIX }}/developer-cuda-sm75:$IMAGE_TAG"
+
+      - name: push developer-cuda-sm75 image
+        run: docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PREFIX }}/developer-cuda-sm75:$IMAGE_TAG"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Both types are available in the following configurations:
     - OpenMPI 4.1.2
     - hypre 2.31.0
 
+- [`cuda-sm75`](https://github.com/mfem/containers/pkgs/container/containers%2Fcuda-sm75)
+    - CUDA toolkit 12.9
+    - OpenMPI 4.1.2
+    - hypre 2.31.0
+
 - [`cpu-tpls`](https://github.com/mfem/containers/pkgs/container/containers%2Fcpu-tpls)
     - OpenMPI 4.1.2
     - hypre 2.31.0
@@ -37,6 +42,10 @@ Both types are available in the following configurations:
 
 - [`developer-cuda-sm89`](https://github.com/mfem/containers/pkgs/container/containers%2Fdeveloper-cuda-sm89)
     - extension of `cuda-sm89` that includes a development environment with VSCode server and GLVis
+    - see the MFEM [AWS tutorial](https://mfem.org/tutorial/docker) for details
+
+- [`developer-cuda-sm75`](https://github.com/mfem/containers/pkgs/container/containers%2Fdeveloper-cuda-sm75)
+    - extension of `cuda-sm75` that includes a development environment with VSCode server and GLVis
     - see the MFEM [AWS tutorial](https://mfem.org/tutorial/docker) for details
 
 Note that the `cuda` images require the host has the


### PR DESCRIPTION
Add sm75--  this is useful for the AWS tutorials so we can use instance type g4dn.xlarge