### PR TITLE
Update the developer container to work with HTTPS

### DIFF
--- a/developer/Dockerfile
+++ b/developer/Dockerfile
@@ -24,11 +24,8 @@ RUN cd  ${HOME}/.openvscode-server/extensions && \
     bsdtar -xvf clangd.vsix extension && \
     mv extension llvm-vs-code-extensions.vscode-clangd-0.1.21
 
-# GLVis JS - clone from fork with HTTPS proxy support
-# TODO using tdrwenski fork just for testing, change back later
-RUN git lfs install && \
-    git clone --depth=1 --branch wss-mixed-content-fix \
-    https://github.com/tdrwenski/glvis-js.git
+# GLVis JS
+RUN git lfs install && git clone --depth=1 https://github.com/GLVis/glvis-js.git
 
 USER root
 ADD supervisord.conf /etc/supervisord.conf

--- a/developer/Dockerfile
+++ b/developer/Dockerfile
@@ -5,7 +5,7 @@ USER root
 
 WORKDIR /opt/archives
 
-RUN apt-get update && apt-get install -y supervisor python3-websockets
+RUN apt-get update && apt-get install -y supervisor python3-websockets nginx
 
 # OpenVSCode server
 RUN curl -L https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-v1.69.1/openvscode-server-v1.69.1-linux-x64.tar.gz > \
@@ -24,12 +24,20 @@ RUN cd  ${HOME}/.openvscode-server/extensions && \
     bsdtar -xvf clangd.vsix extension && \
     mv extension llvm-vs-code-extensions.vscode-clangd-0.1.21
 
-# GLVis JS
-RUN git lfs install && git clone --depth=1 https://github.com/GLVis/glvis-js.git
+# GLVis JS - clone from fork with HTTPS proxy support
+# TODO using tdrwenski fork just for testing, change back later
+RUN git lfs install && \
+    git clone --depth=1 --branch wss-mixed-content-fix \
+    https://github.com/tdrwenski/glvis-js.git
 
 USER root
 ADD supervisord.conf /etc/supervisord.conf
-RUN touch /var/log/glvis-js-webserver.log /var/log/glvis-browser-server.log /var/log/openvscode-server.log && \
-    chown -R euler:euler /var/log/glvis-js-webserver.log /var/log/glvis-browser-server.log /var/log/openvscode-server.log
+
+# Reverse proxy: expose VSCode, the GLVis viewer, and the GLVis websocket on
+# the single tutorial port (3000), routed by path.
+ADD nginx.conf /etc/nginx/nginx.conf
+
+RUN touch /var/log/glvis-js-webserver.log /var/log/glvis-browser-server.log /var/log/openvscode-server.log /var/log/nginx.log && \
+    chown -R euler:euler /var/log/glvis-js-webserver.log /var/log/glvis-browser-server.log /var/log/openvscode-server.log /var/log/nginx.log
 
 CMD ["/usr/bin/supervisord"]

--- a/developer/nginx.conf
+++ b/developer/nginx.conf
@@ -1,0 +1,62 @@
+# Reverse proxy so everything is reachable on the single tutorial port (3000).
+# This lets the deployment sit behind an HTTPS load balancer that only forwards
+# one port: VSCode, the GLVis viewer page, and the GLVis websocket bridge are
+# all served here and routed by path.
+#
+# Runs as the unprivileged 'euler' user, so all writable paths are under /tmp.
+
+worker_processes 1;
+error_log /tmp/nginx-error.log warn;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    access_log /tmp/nginx-access.log;
+
+    client_body_temp_path /tmp/nginx-client;
+    proxy_temp_path /tmp/nginx-proxy;
+    fastcgi_temp_path /tmp/nginx-fastcgi;
+    uwsgi_temp_path /tmp/nginx-uwsgi;
+    scgi_temp_path /tmp/nginx-scgi;
+
+    # Set "Connection: upgrade" only for websocket requests.
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+    server {
+        listen 3000;
+
+        # GLVis websocket bridge (glvis-browser-server on :8080).
+        location /glvis-ws {
+            proxy_pass http://127.0.0.1:8080;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 86400s;
+        }
+
+        # GLVis viewer static site (python http.server on :8000). The trailing
+        # slash strips the /glvis/ prefix, so the page lives at /glvis/live/.
+        location /glvis/ {
+            proxy_pass http://127.0.0.1:8000/;
+        }
+
+        # openvscode-server (moved to :3001). It uses websockets too, so the
+        # upgrade headers are required here as well.
+        location / {
+            proxy_pass http://127.0.0.1:3001;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_read_timeout 86400s;
+        }
+    }
+}

--- a/developer/supervisord.conf
+++ b/developer/supervisord.conf
@@ -20,4 +20,10 @@ command = /home/euler/glvis-js/glvis-browser-server
 environment=HOME="/home/euler",USER="euler"
 redirect_stderr = true
 stdout_logfile = /var/log/openvscode-server.log
-command = /opt/archives/openvscode-server-v1.69.1-linux-x64/bin/openvscode-server --without-connection-token --host 0.0.0.0
+command = /opt/archives/openvscode-server-v1.69.1-linux-x64/bin/openvscode-server --without-connection-token --host 127.0.0.1 --port 3001
+
+[program:nginx]
+environment=HOME="/home/euler",USER="euler"
+redirect_stderr = true
+stdout_logfile = /var/log/nginx.log
+command = nginx -c /etc/nginx/nginx.conf -g "daemon off;"


### PR DESCRIPTION
## Summary
- Route the GLVis viewer and WebSocket bridge through the developer container's Nginx proxy.
- Serve the viewer at `/glvis/live/` and proxy `/glvis-ws` to the internal GLVis bridge.
- Build the developer image with the GLVis HTTPS/WebSocket endpoint support.
- Update the MFEM tutorial link to pass `?socket=/glvis-ws`, so the viewer automatically connects through the public secure route.
## Example
The tutorial link:
`https://<subdomain>.mfem.hpcic.training/glvis/live/?socket=/glvis-ws`
loads the GLVis viewer and automatically connects to:
`wss://<subdomain>.mfem.hpcic.training/glvis-ws`
Nginx proxies that connection to `glvis-browser-server` on internal port `8080`.
## Testing
I have tested on my fork: https://github.com/tdrwenski/containers/pull/2 with images https://github.com/tdrwenski?tab=packages&repo_name=containers in combination with https://github.com/GLVis/glvis-js/pull/39. Locally you have vscode at `http://localhost:3000` and `http://localhost:3000/glvis/live/?socket=/glvis-ws` connects automatically

## Question
The develop docker container still works locally like this but technically if you run locally you don't need nginx. Do you think this is okay or would you prefer a different "tutorial" docker image? or is the developer image mostly for the tutorial?